### PR TITLE
Default to level 1 when run from command line

### DIFF
--- a/runhedy.py
+++ b/runhedy.py
@@ -46,6 +46,9 @@ def main():
                 if level > 8:
                     print("Level has been set to 8, because the value specified was to high")
                     level = 8
+                elif level <= 0:
+                    print("Level has been set to 1, because the value specified was too low")
+                    level = 1
 
     program = '\n'.join([line
         for line in lines

--- a/runhedy.py
+++ b/runhedy.py
@@ -26,7 +26,7 @@ def main():
                 try:
                     level = int(args[2])
                     if level > 8:
-                        print("Level has been set to 8, because the value specified was to high")
+                        print("Level has been set to 8, because the value specified was too high")
                         level = 8
                     elif level <= 0:
                         print("Level has been set to 1, because the value specified was too low")
@@ -44,7 +44,7 @@ def main():
             if len(parts) >= 2:
                 level = int(parts[1])
                 if level > 8:
-                    print("Level has been set to 8, because the value specified was to high")
+                    print("Level has been set to 8, because the value specified was too high")
                     level = 8
                 elif level <= 0:
                     print("Level has been set to 1, because the value specified was too low")

--- a/runhedy.py
+++ b/runhedy.py
@@ -50,6 +50,9 @@ def main():
                     print("Level has been set to 1, because the value specified was too low")
                     level = 1
 
+    if level == 0:
+        level = 1 # Set level to 1 if not provided through other means
+
     program = '\n'.join([line
         for line in lines
         if not line.startswith('#')])

--- a/runhedy.py
+++ b/runhedy.py
@@ -28,6 +28,9 @@ def main():
                     if level > 8:
                         print("Level has been set to 8, because the value specified was to high")
                         level = 8
+                    elif level <= 0:
+                        print("Level has been set to 1, because the value specified was too low")
+                        level = 1
                 except ValueError:
                     print("Level argument is not an integer, skipping argument.")
 


### PR DESCRIPTION
The purpose of this PR is to fix #1341.

The current code base first tries to read the level from the command line. If no level was provided on the command line, we try to find a `#LEVEL <level>` in the source file. If none of these approaches render a level, the level would be left at `0`. This PR ensures that in that situation, the level will be `1`.

As part of this work, I also took the liberty of ensuring that you cannot explicitly set a non-positive level.